### PR TITLE
Implemented getBalanceByAddress via Explorer API

### DIFF
--- a/src/network/ergoNetwork.spec.ts
+++ b/src/network/ergoNetwork.spec.ts
@@ -35,3 +35,7 @@ test("ergoNetwork searchUnspentBoxesByTokensUnion", async t => {
   }
   await t.notThrowsAsync(explorer.searchUnspentBoxesByTokensUnion(req, defaultPaging))
 })
+
+test("ergoNetwork getBalanceByAddress", async t => {
+  await t.notThrowsAsync(explorer.getBalanceByAddress("9iKFBBrryPhBYVGDKHuZQW7SuLfuTdUJtTPzecbQ5pQQzD4VykC"))
+})

--- a/src/network/ergoNetwork.ts
+++ b/src/network/ergoNetwork.ts
@@ -5,12 +5,15 @@ import {Paging} from "./paging"
 import {NetworkContext} from "../entities/networkContext"
 import {
   AugErgoBox,
+  AugErgoBalance,
   AugErgoTx,
   BoxAssetsSearch,
   BoxSearch,
   ExplorerErgoBox,
+  ExplorerErgoBalance,
   ExplorerErgoTx,
   explorerToErgoBox,
+  explorerToErgoBalance,
   explorerToErgoTx,
   fixAssetInfo,
   AugAssetInfo
@@ -27,6 +30,10 @@ export interface ErgoNetwork {
   /** Get confirmed output by id.
    */
   getOutput(id: BoxId): Promise<AugErgoBox | undefined>
+
+  /** Get confirmed balance by address.
+   */
+  getBalanceByAddress(address: Address): Promise<AugErgoBalance | undefined>
 
   /** Get transactions by address.
    */
@@ -108,6 +115,15 @@ export class Explorer implements ErgoNetwork {
         transformResponse: data => JSONBI.parse(data)
       })
       .then(res => explorerToErgoBox(res.data))
+  }
+
+  async getBalanceByAddress(address: Address): Promise<AugErgoBalance | undefined> {
+    return this.backend
+      .request<ExplorerErgoBalance>({
+        url: `/api/v1/addresses/${address}/balance/confirmed`,
+        transformResponse: data => JSONBI.parse(data)
+      })
+      .then(res => explorerToErgoBalance(res.data))
   }
 
   async getTxsByAddress(address: Address, paging: Paging): Promise<[AugErgoTx[], number]> {

--- a/src/network/models.ts
+++ b/src/network/models.ts
@@ -36,6 +36,20 @@ export function explorerToInput(ein: ExplorerInput): AugInput {
   }
 }
 
+export type ExplorerErgoBalance = {
+  readonly nErgs: bigint
+  readonly tokens: BoxAsset[]
+}
+
+export type AugErgoBalance = {
+  readonly nErgs: bigint
+  readonly tokens: BoxAsset[]
+}
+
+export function explorerToErgoBalance(balance: ExplorerErgoBalance): AugErgoBalance {
+  return {...balance}
+}
+
 export type ExplorerErgoTx = {
   readonly id: TxId
   readonly inputs: ExplorerInput[]


### PR DESCRIPTION
**Description:**
Quick get wallet balance with single call. Useful for both normal and watch-only wallets.

Result:
![img](https://i.imgur.com/OUr4BMV.png)

**Added:**
- `getBalanceByAddress` in Explorer

**Issues**
- Unit test for `boxSelector` failed, I don't why, but whole package still work fine